### PR TITLE
Create shipments

### DIFF
--- a/shipments
+++ b/shipments
@@ -1,0 +1,4 @@
+fn count_permutation(shipments: &[u32]) -> usize
+fn count_permutation(shipments: &Vec<u32>) -> i32
+fn count_permutation<I>(shipments: I) -> usize
+where I: IntoIterator<Item = u32>


### PR DESCRIPTION
У мові програмування Rust, функція count_permutation приймає посилання на вектор вантажів типу Vec<u32> і повертає значення типу usize, яке представляє мінімальну кількість переміщень вантажу для вирівнювання на всіх кораблях.

Якщо потрібно працювати з колекціями загального типу, що реалізують певні трейти, можна використати узагальнення. Наприклад, якщо функція повинна працювати з будь-якими типами, що реалізують інтерфейс AsRef<[u32]>:

сигнатуру, яка найкраще відповідає вашим вимогам щодо типу аргументів та їх використання в функції.